### PR TITLE
Include FileSystemConfig in KernelGatewayImageConfig

### DIFF
--- a/src/deploy/cf/publish-sagemaker-kernel.yml
+++ b/src/deploy/cf/publish-sagemaker-kernel.yml
@@ -115,7 +115,7 @@ Resources:
     Properties:
       ServiceToken: !GetAtt KernelPublishFunction.Arn
       config: !Sub
-          - "{\"ecr_repo_name\":\"${RepoName}\",\"image_name\":\"${ImageName}\",\"image_permissions\":\"${RoleArn}\",\"app_image_config\":{\"AppImageConfigName\":\"${ImageName}-config\",\"KernelGatewayImageConfig\":{\"KernelSpecs\":[{\"Name\":\"python3\",\"DisplayName\":\"Python 3\"}]}},\"update_domain_input\":{\"DomainId\":\"${StudioId}\",\"DefaultUserSettings\":{\"KernelGatewayAppSettings\":{\"CustomImages\":[{\"ImageName\":\"${ImageName}\",\"AppImageConfigName\":\"${ImageName}-config\"}]}}}}"
+          - "{\"ecr_repo_name\":\"${RepoName}\",\"image_name\":\"${ImageName}\",\"image_permissions\":\"${RoleArn}\",\"app_image_config\":{\"AppImageConfigName\":\"${ImageName}-config\",\"KernelGatewayImageConfig\":{\"FileSystemConfig\":{\"DefaultGid\":0,\"DefaultUid\":0,\"MountPath\": \"/home/sagemaker-user\"},\"KernelSpecs\":[{\"Name\":\"python3\",\"DisplayName\":\"Python 3\"}]}},\"update_domain_input\":{\"DomainId\":\"${StudioId}\",\"DefaultUserSettings\":{\"KernelGatewayAppSettings\":{\"CustomImages\":[{\"ImageName\":\"${ImageName}\",\"AppImageConfigName\":\"${ImageName}-config\"}]}}}}"
           - ImageName: !Ref pKernelImageName  
             RepoName: !Ref pRepoName
             StudioId: !Ref pDomainId


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The default `snowflake` kernel image built by the associated [Dockerfile](https://github.com/aws-samples/amazon-sagemaker-kernel-builder/blob/main/kernels/snowflake/Dockerfile) uses a base image that has a default user POSIX UID and GID of 0. But by default, SageMaker runs your image as the “sagemaker-user” with a POSIX UID of 1000 and GID of 100. SageMaker Studio will return an error similar to _SageMaker is unable to launch the app using the image [...]. Ensure that the UID/GID provided in the AppImageConfig matches the default UID/GID defined in the image_  if this configuration is not changed from the default. Ref [here](https://github.com/aws-samples/sagemaker-studio-custom-image-samples/blob/main/DEVELOPMENT.md#uidgid-mismatch-between-appimageconfig-and-dockerfile).

This change sets the default `FileSystemConfig` on the `KernelGatewayImageConfig`, in the KernelPublishWorkflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
